### PR TITLE
Allows user to hold L button on boot to automatically load first NOR file

### DIFF
--- a/source/ezkernel.c
+++ b/source/ezkernel.c
@@ -1640,6 +1640,15 @@ int main(void) {
 		memset(pNorFS,00,sizeof(FM_NOR_FS)*MAX_NOR);
 		Save_NOR_info(pNorFS,sizeof(FM_NOR_FS)*MAX_NOR);
 	}
+	else {
+		VBlankIntrWait();
+		scanKeys();
+		if(keysDownRepeat() & KEY_L || keysDown() & KEY_L)
+		{
+			page_num = NOR_list;
+			goto load_file;
+		}
+	}
 
 refind_file:
 	
@@ -2206,6 +2215,9 @@ re_showfile:
 			}
 			ShowTime(page_num,page_mode);
 		}	//3
+
+load_file:
+
 
 		Clear(0, 0, 240, 160, gl_color_cheat_black, 1);
 		DrawHZText12(gl_Loading,0,(240-strlen(gl_Loading)*6)/2,74, gl_color_text,1);


### PR DESCRIPTION
Adds code to automatically boot into the first game in the NOR file list (assuming there is such a game) when the user holds the `L` key during boot.

I am not sure how to update `crc32` to deploy a new FW version number. Please advise or patch :)

This fills a feature request from this reddit thread: https://www.reddit.com/r/Gameboy/comments/9cedpi/lets_work_on_the_ezflash_omega_tldr_at_the_bottom/e5b3cp1/
